### PR TITLE
[MED] support for Conditional/Setter flds of med::set

### DIFF
--- a/med/mandatory.hpp
+++ b/med/mandatory.hpp
@@ -246,6 +246,19 @@ struct mandatory<
 {
 };
 
+//M<TAG, FIELD, SETTER>
+template <ATag TAG, AField FIELD, class SETTER> requires ASetter<FIELD, SETTER>
+struct mandatory<
+	TAG,
+	FIELD,
+	SETTER,
+	min<1>,
+	max<1>
+> : field_t<FIELD, add_tag<TAG>>
+{
+	using setter_type = SETTER;
+};
+
 //M<TAG, FIELD, arity<NUM>
 template <ATag TAG, AField FIELD, std::size_t NUM>
 struct mandatory<

--- a/med/optional.hpp
+++ b/med/optional.hpp
@@ -274,6 +274,19 @@ struct optional<
 {
 };
 
+//single-instance field as a part of compound
+template <ATag TAG, AField FIELD, ACondition CONDITION>
+struct optional<
+	TAG,
+	FIELD,
+	CONDITION,
+	min<1>,
+	max<1>
+> : field_t<FIELD, add_tag<TAG>>, optional_t
+{
+	using condition = CONDITION;
+};
+
 //multi-instance field w/ tag
 template <ATag TAG, AField FIELD, std::size_t MAX>
 struct optional<

--- a/ut/ut_proto.hpp
+++ b/ut/ut_proto.hpp
@@ -229,6 +229,7 @@ struct FLD_QTY : med::value<uint8_t>
 			}
 		}
 	};
+	static constexpr char const* name() { return "Fld-Qty"; }
 };
 
 struct FLD_FLAGS : med::value<uint8_t>
@@ -293,6 +294,7 @@ struct FLD_FLAGS : med::value<uint8_t>
 			//ies.template as<FLD_FLAGS>().set(bits);
 		}
 	};
+	static constexpr char const* name() { return "Fld-Flags"; }
 };
 
 //optional fields with functors
@@ -309,13 +311,28 @@ struct MSG_FUNC : med::sequence<
 	static constexpr char const* name() { return "Msg-With-Functors"; }
 };
 
+//optional fields with functors
+struct MSG_SET_FUNC : med::set<
+	M< T16<0x0b>, FLD_UC >, //<TV>
+	M< T16<0x0d>, FLD_FLAGS, FLD_FLAGS::setter >,
+	O< T16<0x0e>, FLD_QTY, FLD_FLAGS::has_bits<FLD_FLAGS::QTY> >,
+	O< T16<0x0c>, FLD_U8 >, //<TV>
+	O< T16<0x21>, FLD_U16, FLD_FLAGS::has_bits<FLD_FLAGS::U16> >,
+	O< T16<0x49>, FLD_U24, FLD_FLAGS::has_bits<FLD_FLAGS::U24> >,
+	O< T16<0x89>, FLD_IP >
+>
+{
+	static constexpr char const* name() { return "Msg-Set-With-Functors"; }
+	decltype(auto) body() const         { return this->m_ies; }
+};
 
 struct PROTO : med::choice<
 	M<C<0x01>, MSG_SEQ>,
 	M<C<0x11>, MSG_MSEQ>,
 	M<C<0x04>, MSG_SET>,
 	M<C<0x14>, MSG_MSET>,
-	M<C<0xFF>, MSG_FUNC>
+	M<C<0xFF>, MSG_FUNC>,
+	M<C<0x24>, MSG_SET_FUNC>
 >
 {
 };


### PR DESCRIPTION
- Added support for the cases like this:

    struct MSG_SET_FUNC : med::set<
           M< T16<0x0b>, FLD_UC >, //<TV>
           M< T16<0x0d>, FLD_FLAGS, FLD_FLAGS::setter >,
           O< T16<0x0e>, FLD_QTY, FLD_FLAGS::has_bits<FLD_FLAGS::QTY> >
    >{};

- This is quite an exotic case, since, strictly speaking, presence of conditional fields in a med::set is not required for successful decoding

- Please note, that it is support for single-instance fields only. Also, there is yet no support for Counter fields in a med::set