### PR TITLE
more codec traces

### DIFF
--- a/med/allocator.hpp
+++ b/med/allocator.hpp
@@ -22,6 +22,7 @@ struct null_allocator
 	[[nodiscard]]
 	void* allocate(std::size_t bytes, std::size_t /*alignment*/) const
 	{
+		CODEC_TRACE("%s", __FUNCTION__);
 		MED_THROW_EXCEPTION(out_of_memory, __FUNCTION__, bytes);
 	}
 };
@@ -29,6 +30,7 @@ struct null_allocator
 template <typename T, class ALLOCATOR, class... ARGs>
 T* create(ALLOCATOR& alloc, ARGs&&... args)
 {
+	CODEC_TRACE("%s", __FUNCTION__);
 	void* p = alloc.allocate(sizeof(T), alignof(T));
 	if (!p) { MED_THROW_EXCEPTION(out_of_memory, name<T>(), sizeof(T)); }
 	return new (p) T{std::forward<ARGs>(args)...};

--- a/med/container.hpp
+++ b/med/container.hpp
@@ -113,18 +113,18 @@ struct cont_is
 		//optional or mandatory field w/ setter => can be set implicitly
 		if constexpr (AOptional<IE> || AHasSetterType<IE>)
 		{
-			//CODEC_TRACE("is_set[%s]=%d", name<IE>(), static_cast<IE const&>(seq).is_set());
+			CODEC_TRACE("O/S[%s] is_set=%d", name<IE>(), static_cast<IE const&>(seq).is_set());
 			return static_cast<IE const&>(seq).is_set();
 		}
 		else //mandatory field w/o setter => s.b. set explicitly
 		{
+			CODEC_TRACE("M[%s]%s is_set=%d", name<IE>(), (APredefinedValue<IE> ? "[init/const]":""), static_cast<IE const&>(seq).is_set());
 			if constexpr (APredefinedValue<IE>) //don't account predefined IEs like init/const
 			{
 				return false;
 			}
 			else
 			{
-				//CODEC_TRACE("is_set[%s]=%d", name<IE>(), static_cast<IE const&>(seq).is_set());
 				return static_cast<IE const&>(seq).is_set();
 			}
 		}

--- a/med/decode.hpp
+++ b/med/decode.hpp
@@ -33,7 +33,7 @@ constexpr auto decode_tag(auto& decoder)
 	TAG_TYPE ie;
 	typename as_writable_t<TAG_TYPE>::value_type value{};
 	value = decoder(ie, IE_TAG{});
-	CODEC_TRACE("%s=%zX [%s]", __FUNCTION__, std::size_t(value), class_name<TAG_TYPE>());
+	CODEC_TRACE("%s=0x%zX(%zu) [%s]", __FUNCTION__, std::size_t(value), std::size_t(value), class_name<TAG_TYPE>());
 	return value;
 }
 //Length

--- a/med/encode.hpp
+++ b/med/encode.hpp
@@ -149,7 +149,7 @@ template <class ENCODER, AHasIeType IE>
 constexpr void encode(ENCODER&& encoder, IE const& ie)
 {
 	using META_INFO = meta::produce_info_t<ENCODER, IE>;
-	//CODEC_TRACE("mi=%s", class_name<META_INFO>());
+	CODEC_TRACE("mi=%s by %s for %s", class_name<META_INFO>(), class_name<ENCODER>(), class_name<IE>());
 	sl::ie_encode<type_context<typename IE::ie_type, META_INFO>>(encoder, ie);
 }
 

--- a/med/field.hpp
+++ b/med/field.hpp
@@ -198,7 +198,7 @@ public:
 						m_tail = prev.m_curr;
 					}
 				}
-				CODEC_TRACE("%s(%s=%p) count=%zu head=%p tail=%p", __FUNCTION__, name<field_type>(), it.get(), count(), m_head, m_tail);
+				CODEC_TRACE("%s(%s=%p) count=%zu head=%p tail=%p", __FUNCTION__, name<field_type>(), (void*)it.get(), count(), (void*)m_head, (void*)m_tail);
 				return ret;
 			}
 			prev = it;
@@ -220,7 +220,7 @@ private:
 		{
 			for (auto& f : m_fields)
 			{
-				CODEC_TRACE("%s: %s=%p[%c]", __FUNCTION__, name<field_type>(), (void*)&f, f.value.is_set()?'+':'-');
+				CODEC_TRACE("%s: %s=%p[%c][%zu]", __FUNCTION__, name<field_type>(), (void*)&f, f.value.is_set()?'+':'-', inplace);
 				if (!f.value.is_set()) return &f;
 			}
 		}
@@ -235,7 +235,7 @@ private:
 		else { m_head = m_tail = pf; }
 		pf->next = nullptr;
 		m_tail = pf;
-		CODEC_TRACE("%s(%s=%p) count=%zu head=%p tail=%p", __FUNCTION__, name<field_type>(), (void*)pf, count(), m_head, m_tail);
+		CODEC_TRACE("%s(%s=%p) count=%zu head=%p tail=%p", __FUNCTION__, name<field_type>(), (void*)pf, count(), (void*)m_head, (void*)m_tail);
 		return &m_tail->value;
 	}
 

--- a/med/length.hpp
+++ b/med/length.hpp
@@ -147,7 +147,6 @@ constexpr void length_to_value(FIELD& field, std::size_t len)
 		{
 			field.set_length(len);
 		}
-		CODEC_TRACE("L=%zXh(%zX) [%s]:", len, std::size_t(field.get_encoded()), name<FIELD>());
 	}
 	else if constexpr (std::is_same_v<bool, decltype(field.set_encoded(0))>)
 	{
@@ -160,6 +159,7 @@ constexpr void length_to_value(FIELD& field, std::size_t len)
 	{
 		field.set_encoded(len);
 	}
+	CODEC_TRACE("L=%zXh(%zX) [%s]:", len, std::size_t(field.get_encoded()), name<FIELD>());
 }
 
 template <class FIELD>

--- a/med/octet_decoder.hpp
+++ b/med/octet_decoder.hpp
@@ -82,7 +82,7 @@ struct octet_decoder : sl::octet_info
 				if constexpr (IE::traits::offset)
 				{
 					constexpr size_t MASK = (size_t(1) << (NUM_BYTES * 8 - IE::traits::offset)) - 1;
-					//CODEC_TRACE("V=%zXh(%zu) M=%zXh", res, NUM_BYTES, MASK);
+					CODEC_TRACE("V=%zXh(%zu) M=%zXh", res, NUM_BYTES, MASK);
 					res &= MASK;
 				}
 				constexpr uint8_t RS = NUM_BYTES * 8 - NUM_BITS;

--- a/med/sequence.hpp
+++ b/med/sequence.hpp
@@ -362,7 +362,7 @@ struct seq_enc
 				}
 				else //w/o setter
 				{
-					//CODEC_TRACE("%c{%s}", ie.is_set()?'+':'-', class_name<IE>());
+					CODEC_TRACE("%c{%s}", ie.is_set()?'+':'-', class_name<IE>());
 					if (AHasSetLength<IE> || ie.is_set())
 					{
 						med::encode(encoder, ie);

--- a/med/set.hpp
+++ b/med/set.hpp
@@ -108,6 +108,7 @@ struct set_dec
 	{
 		using mi = meta::produce_info_t<DECODER, IE>;
 		using tag_t = get_info_t<meta::list_first_t<mi>>;
+		CODEC_TRACE("%zu tag match%c for %s(%s)", size_t(get_tag(header)), (tag_t::match(get_tag(header))? '+':'-'), name<tag_t>(), name<IE>());
 		return tag_t::match( get_tag(header) );
 	}
 
@@ -226,7 +227,7 @@ struct set : detail::set_container<meta::typelist<IEs...>>
 			{
 				value<std::size_t> header;
 				header.set_encoded(sl::decode_tag<tag_t>(decoder));
-				CODEC_TRACE("tag=%#zX", std::size_t(get_tag(header)));
+				CODEC_TRACE("tag=%#zX mi=%s firstIE=%s tag_t=%s", std::size_t(get_tag(header)), class_name<mi>(), name<IE>(), name<tag_t>());
 				meta::for_if<ies_types>(sl::set_dec{}, this->m_ies, decoder, header, deps...);
 			}
 		}
@@ -238,7 +239,7 @@ struct set : detail::set_container<meta::typelist<IEs...>>
 				header_type header;
 				med::decode(decoder, header, deps...);
 				decoder(POP_STATE{}); //restore back for IE to decode itself (?TODO: better to copy instead)
-				CODEC_TRACE("tag=%#zX", std::size_t(get_tag(header)));
+				CODEC_TRACE("tag=%#zX hdr=%s", std::size_t(get_tag(header)), class_name<header_type>());
 				meta::for_if<ies_types>(sl::set_dec{}, this->m_ies, decoder, header, deps...);
 			}
 		}


### PR DESCRIPTION
- codec traces were added or extended. Yes, they are tending to look like more wordy, but it less painful than recompilation of a big project each time when some more MED traces needed
- small compilation bug fixed for traces introduced while fixing issue with multifield internal list