### PR TITLE
[MED] OCTET_STRING improvements

### DIFF
--- a/med/container.hpp
+++ b/med/container.hpp
@@ -113,12 +113,12 @@ struct cont_is
 		//optional or mandatory field w/ setter => can be set implicitly
 		if constexpr (AOptional<IE> || AHasSetterType<IE>)
 		{
-			CODEC_TRACE("O/S[%s] is_set=%d", name<IE>(), static_cast<IE const&>(seq).is_set());
+			// CODEC_TRACE("O/S[%s] is_set=%d", name<IE>(), static_cast<IE const&>(seq).is_set());
 			return static_cast<IE const&>(seq).is_set();
 		}
 		else //mandatory field w/o setter => s.b. set explicitly
 		{
-			CODEC_TRACE("M[%s]%s is_set=%d", name<IE>(), (APredefinedValue<IE> ? "[init/const]":""), static_cast<IE const&>(seq).is_set());
+			// CODEC_TRACE("M[%s]%s is_set=%d", name<IE>(), (APredefinedValue<IE> ? "[init/const]":""), static_cast<IE const&>(seq).is_set());
 			if constexpr (APredefinedValue<IE>) //don't account predefined IEs like init/const
 			{
 				return false;

--- a/med/field.hpp
+++ b/med/field.hpp
@@ -220,7 +220,7 @@ private:
 		{
 			for (auto& f : m_fields)
 			{
-				CODEC_TRACE("%s: %s=%p[%c][%zu]", __FUNCTION__, name<field_type>(), (void*)&f, f.value.is_set()?'+':'-', inplace);
+				// CODEC_TRACE("%s: %s=%p[%c][%zu]", __FUNCTION__, name<field_type>(), (void*)&f, f.value.is_set()?'+':'-', inplace);
 				if (!f.value.is_set()) return &f;
 			}
 		}

--- a/med/octet_string.hpp
+++ b/med/octet_string.hpp
@@ -18,6 +18,8 @@ Distributed under the MIT License
 
 namespace med {
 
+constexpr std::size_t MAX_OCTS = std::numeric_limits<num_octs_t>::max();
+
 template <std::size_t MIN, std::size_t MAX>
 struct octets
 {
@@ -202,7 +204,7 @@ struct octet_string_impl : IE<IE_OCTET_STRING>
 				return false;
 			}
 		}
-		if constexpr (traits::max_octets != inf())
+		if constexpr (traits::max_octets != MAX_OCTS)
 		{
 			if (len > traits::max_octets)
 			{
@@ -252,8 +254,6 @@ struct ascii_string : octet_string<T...>
 		std::snprintf(sz, sizeof(sz), "%.*s", int(s.size()), s.data());
 	}
 };
-
-constexpr std::size_t MAX_OCTS = std::numeric_limits<num_octs_t>::max();
 
 template <class VALUE>
 struct octet_string<VALUE, void, void>
@@ -311,8 +311,13 @@ struct octet_string<octets_fix_intern<FIXED>, void, void>
 
 	void set(uint8_t const(&data)[FIXED])   { this->set_encoded(FIXED, &data[0]); }
 };
+
 template <std::size_t MAX, std::size_t MIN>
 struct octet_string<octets_var_intern<MAX>, min<MIN>, void>
 		: octet_string_impl<detail::octet_traits<uint8_t, MIN, MAX>, octets_var_intern<MAX>> {};
-
+template <std::size_t MAX>
+struct octet_string<octets_var_intern<MAX>, void, void>
+		: octet_string_impl<detail::octet_traits<uint8_t, 0, MAX>, octets_var_intern<MAX>>
+{
+};
 }	//end: namespace med


### PR DESCRIPTION
- bug fix, a wrong constant was used in the length checker, med::inf() instead of MAX_OCTETS
- add specialization of octet_string < octets_var_intern<N> > so as to propagate N into traits::maximum_octets
- too wordy TRACEs were commented